### PR TITLE
add 5MB sized lru cache to levenshtein distance function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,8 @@
     "@types/lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-8mNEUG6diOrI6pMqOHrHPDBB1JsrpedeMK9AWGzVCQ7StRRribiT9BRvUmF8aUws9iBbVlgVekOT5Sgzc1MTKw=="
+      "integrity": "sha512-8mNEUG6diOrI6pMqOHrHPDBB1JsrpedeMK9AWGzVCQ7StRRribiT9BRvUmF8aUws9iBbVlgVekOT5Sgzc1MTKw==",
+      "dev": true
     },
     "@types/micro": {
       "version": "7.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,11 @@
       "integrity": "sha512-fQ61KKDKyEztu4AdZOKGBHz6h4UpDiuMJOhA8A+GsNF+mwBnTtBwVwoU/oDyRDrigB10v5gvZApNqEXyBKmYVg==",
       "dev": true
     },
+    "@types/lru-cache": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-8mNEUG6diOrI6pMqOHrHPDBB1JsrpedeMK9AWGzVCQ7StRRribiT9BRvUmF8aUws9iBbVlgVekOT5Sgzc1MTKw=="
+    },
     "@types/micro": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/@types/micro/-/micro-7.3.1.tgz",
@@ -609,6 +614,24 @@
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        }
       }
     },
     "csproj2ts": {
@@ -2330,13 +2353,11 @@
       }
     },
     "lru-cache": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-      "dev": true,
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "yallist": "^3.0.2"
       }
     },
     "map-cache": {
@@ -4318,10 +4339,9 @@
       "dev": true
     },
     "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
     },
     "yargs": {
       "version": "11.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "description": "",
   "main": "lib/index.js",
   "dependencies": {
-    "@types/lru-cache": "^4.1.1",
     "faker": "^4.1.0",
     "fast-levenshtein": "^2.0.6",
     "graphql": "^14.0.0",
@@ -20,6 +19,7 @@
   "devDependencies": {
     "@types/faker": "^4.1.4",
     "@types/graphql": "^14.0.0",
+    "@types/lru-cache": "^4.1.1",
     "@types/micro": "^7.3.1",
     "@types/mongoose": "^5.0.18",
     "@types/node": "^10.1.2",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "description": "",
   "main": "lib/index.js",
   "dependencies": {
+    "@types/lru-cache": "^4.1.1",
     "faker": "^4.1.0",
     "fast-levenshtein": "^2.0.6",
     "graphql": "^14.0.0",
+    "lru-cache": "^5.1.1",
     "micro": "^9.3.1",
     "mongoose": "^5.1.7",
     "node-fetch": "^2.1.2",

--- a/src/levenshtein.ts
+++ b/src/levenshtein.ts
@@ -1,4 +1,5 @@
 import * as levenshtein from "fast-levenshtein";
+import * as LRU from "lru-cache"
 
 export type keyMapObject = {
   name: string;
@@ -6,7 +7,17 @@ export type keyMapObject = {
   value: string;
 };
 
+// 5MB Cache 
+var lru = new LRU({
+  max: 5 * 1024 * 1024,
+  maxAge: 1000 * 60 * 60,
+  length: (n: string, key: string) => { return n.length + key.length }
+})
+
 export const compare = (s: string, all: keyMapObject[]) => {
+  if (lru.has(s)) {
+    return lru.get(s)
+  }
   let minDistance = Infinity;
   let bestMatch = s;
   for (var st of all) {
@@ -26,6 +37,6 @@ export const compare = (s: string, all: keyMapObject[]) => {
       minDistance = distance2;
     }
   }
-  console.log(s, bestMatch);
+  lru.set(s, bestMatch)
   return bestMatch;
 };


### PR DESCRIPTION
Leveshtein distance is slow, but reusable, add global cache for matches.